### PR TITLE
Source entity and source-validation package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ name = "entity"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "regex",
  "serde",
  "uuid",
 ]

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -8,3 +8,4 @@ authors.workspace = true
 serde.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+regex = "1.11.1"

--- a/entity/src/source.rs
+++ b/entity/src/source.rs
@@ -1,15 +1,114 @@
-use chrono::{DateTime, NaiveDate, Utc};
 use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, de};
+use serde::de::Visitor;
+use std::fmt;
+use regex::Regex;
 
+/// A website or book source created by a user
+#[derive(Debug)]
 pub struct Source {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
     pub created_by: Uuid,
-    pub url: String,
-    pub title: Option<String>,
-    pub author: Option<String>,
-    pub publication: Option<String>,
-    pub publication_date: Option<NaiveDate>,
-    pub content_summary: Option<String>,
     pub credibility: f32,
+    pub source_info: SourceInfo,
+}
+
+/// Details about a particular website or a list of book matches
+#[derive(Debug)]
+pub enum SourceInfo {
+    Website(WebsiteInfo),
+    Book(Vec<BookInfo>),
+}
+
+/// Details about a particular website
+#[derive(Deserialize)]
+#[derive(Debug)]
+pub struct WebsiteInfo {
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub authors: Option<Vec<String>>,
+    pub publisher: Option<String>,
+    pub date: PublicationDate,
+    pub description: Option<String>,
+}
+
+/// Details about a particular book
+#[derive(Deserialize)]
+#[derive(Debug)]
+pub struct BookInfo {
+    pub title: Option<String>,
+    pub authors: Option<Vec<String>>,
+    pub publisher: Option<String>,
+    pub date: PublicationDate,
+    pub categories: Option<Vec<String>>,
+    pub pages: Option<i32>,
+}
+
+/// A source publication date consisting of a year, month, and day
+#[derive(Debug)]
+pub struct PublicationDate {
+    pub year: Option<u16>,
+    pub month: Option<u8>,
+    pub day: Option<u8>,
+}
+
+impl Source {
+    /// Construct a new Source object (with a new id) given SourceInfo
+    pub fn new(source_info: SourceInfo) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            created_at: Utc::now(),
+            created_by: Uuid::nil(), // TODO: fetch user uuid
+            credibility: 0.0, // TODO: implement credibility
+            source_info
+        }
+    }
+}
+
+/// Custom Deserializer for PublicationDate to parse strings of the form '[yyyy][-mm][-dd]'
+impl<'de> Deserialize<'de> for PublicationDate {
+    fn deserialize<D>(deserializer: D) -> Result<PublicationDate, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct DateVisitor;
+
+        impl<'de> Visitor<'de> for DateVisitor {
+            type Value = PublicationDate;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string of the form '[yyyy][-mm][-dd]'")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let re = Regex::new(r"^(?<y>[0-9]{4})?(-(?<m>[0-9]{2}))?(-(?<d>[0-9]{2}))?$").unwrap();
+
+                if let Some(cap) = re.captures_iter(value).last() {
+                    let mut year = None;
+                    let mut month = None;
+                    let mut day = None;
+
+                    if let Some(year_match) = cap.name("y") {
+                        year = Some(year_match.as_str().parse().unwrap());
+                    }
+                    if let Some(month_match) = cap.name("m") {
+                        month = Some(month_match.as_str().parse().unwrap());
+                    }
+                    if let Some(day_match) = cap.name("d") {
+                        day = Some(day_match.as_str().parse().unwrap());
+                    }
+                    Ok(PublicationDate { year, month, day })
+                } else {
+                    Err(E::custom(format!("date string format incorrect: {}", value)))
+                }
+            }
+        }
+        
+        deserializer.deserialize_string(DateVisitor)
+    }
 }

--- a/entity/src/source.rs
+++ b/entity/src/source.rs
@@ -13,6 +13,7 @@ pub struct Source {
     pub created_by: Uuid,
     pub credibility: f32,
     pub source_info: SourceInfo,
+    pub notes: String,
 }
 
 /// Details about a particular website or a list of book matches
@@ -23,10 +24,9 @@ pub enum SourceInfo {
 }
 
 /// Details about a particular website
-#[derive(Deserialize)]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct WebsiteInfo {
-    pub url: Option<String>,
+    pub url: String,
     pub title: Option<String>,
     pub authors: Option<Vec<String>>,
     pub publisher: Option<String>,
@@ -35,10 +35,9 @@ pub struct WebsiteInfo {
 }
 
 /// Details about a particular book
-#[derive(Deserialize)]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct BookInfo {
-    pub title: Option<String>,
+    pub title: String,
     pub authors: Option<Vec<String>>,
     pub publisher: Option<String>,
     pub date: PublicationDate,
@@ -47,8 +46,7 @@ pub struct BookInfo {
 }
 
 /// A source publication date consisting of a year, month, and day
-#[derive(PartialEq)]
-#[derive(Debug)]
+#[derive(PartialEq, Debug)]
 pub struct PublicationDate {
     pub year: Option<u16>,
     pub month: Option<u8>,
@@ -63,7 +61,8 @@ impl Source {
             created_at: Utc::now(),
             created_by: Uuid::nil(), // TODO: fetch user uuid
             credibility: 0.0, // TODO: implement credibility
-            source_info
+            source_info,
+            notes: String::new(),
         }
     }
 }

--- a/source_validation/Cargo.toml.txt
+++ b/source_validation/Cargo.toml.txt
@@ -1,0 +1,7 @@
+[package]
+name = "matchmaking"
+edition = "2024"
+version.workspace = true
+authors.workspace = true
+
+[dependencies]

--- a/source_validation/src/lib.rs
+++ b/source_validation/src/lib.rs
@@ -44,17 +44,6 @@ async fn extract_source_book(name: &str) -> Result<Source, Box<dyn Error>> {
         .text()
         .await?;
 
-    let ds = &mut serde_json::Deserializer::from_str(&response);
-
-    let result: Result<Vec<BookInfo>, _> = serde_path_to_error::deserialize(ds);
-    match result {
-        Err(err) => {
-            let path = err.path().to_string();
-            eprintln!("ERROR PATH = {path}");
-        }
-        _ => ()
-    }
-
     let book_info = serde_json::from_str(&response)?;
     let source_info = SourceInfo::Book(book_info);
     let source = Source::new(source_info);

--- a/source_validation/src/main.rs
+++ b/source_validation/src/main.rs
@@ -1,0 +1,63 @@
+use source::{Source, SourceInfo, WebsiteInfo, BookInfo};
+use std::error::Error;
+
+pub mod source;
+
+// Extract source info from a website URL using the Bibify API.
+async fn extract_source_url(url: &str) -> Result<Source, Box<dyn Error>> {
+    let request_target = r#"https://api.bibify.org/api/website"#;
+    let query = [("url", url)];
+
+    let client = reqwest::Client::new();
+
+    let request = client.request(reqwest::Method::GET, request_target)
+        .query(&query)
+        .build()
+        .unwrap();
+
+    let response = client.execute(request)
+        .await?
+        .text()
+        .await?;
+
+    let website_info: WebsiteInfo = serde_json::from_str(&response)?;
+    let source_info = SourceInfo::Website(website_info);
+    let source = Source::new(source_info);
+
+    Ok(source)
+}
+
+// Extract source info from a book by its name using the Bibify API. Returns a list of matches.
+async fn extract_source_book(name: &str) -> Result<Source, Box<dyn Error>> {
+    let request_target = r#"https://api.bibify.org/api/books"#;
+    let query = [("q", name)];
+
+    let client = reqwest::Client::new();
+
+    let request = client.request(reqwest::Method::GET, request_target)
+        .query(&query)
+        .build()
+        .unwrap();
+
+    let response = client.execute(request)
+        .await?
+        .text()
+        .await?;
+
+    let ds = &mut serde_json::Deserializer::from_str(&response);
+
+    let result: Result<Vec<BookInfo>, _> = serde_path_to_error::deserialize(ds);
+    match result {
+        Err(err) => {
+            let path = err.path().to_string();
+            eprintln!("ERROR PATH = {path}");
+        }
+        _ => ()
+    }
+
+    let book_info = serde_json::from_str(&response)?;
+    let source_info = SourceInfo::Book(book_info);
+    let source = Source::new(source_info);
+
+    Ok(source)
+}


### PR DESCRIPTION
The Source entity is serde deserializable and has matching fields to the Bibify API's JSON output. We are currently missing an implementation for measuring the credibility score of a given source. The source-validation package uses Bibify and serde_json to create a Source object given a website URL or book name.